### PR TITLE
fix: trim space

### DIFF
--- a/pkg/virtualization/vmdk/vmdk.go
+++ b/pkg/virtualization/vmdk/vmdk.go
@@ -161,7 +161,7 @@ func ParseDiskDescriptor(rs io.ReadSeeker, header Header) (DiskDescriptor, error
 			if currentSectionFunc == nil {
 				return DiskDescriptor{}, xerrors.Errorf("invalid descriptor")
 			}
-			err := currentSectionFunc(line, &descriptor)
+			err := currentSectionFunc(strings.TrimSpace(line), &descriptor)
 			if err != nil {
 				return DiskDescriptor{}, err
 			}
@@ -201,8 +201,7 @@ func parseExtentDescription(line string, dd *DiskDescriptor) error {
 	return nil
 }
 
-func parseDiskDescriptorFile(rawLine string, dd *DiskDescriptor) error {
-	line := strings.TrimSpace(rawLine)
+func parseDiskDescriptorFile(line string, dd *DiskDescriptor) error {
 	switch {
 	case strings.HasPrefix(line, "version="):
 		vstr := strings.TrimPrefix(line, "version=")

--- a/pkg/virtualization/vmdk/vmdk.go
+++ b/pkg/virtualization/vmdk/vmdk.go
@@ -201,7 +201,8 @@ func parseExtentDescription(line string, dd *DiskDescriptor) error {
 	return nil
 }
 
-func parseDiskDescriptorFile(line string, dd *DiskDescriptor) error {
+func parseDiskDescriptorFile(rawLine string, dd *DiskDescriptor) error {
+	line := strings.TrimSpace(rawLine)
 	switch {
 	case strings.HasPrefix(line, "version="):
 		vstr := strings.TrimPrefix(line, "version=")

--- a/pkg/virtualization/vmdk/vmdk.go
+++ b/pkg/virtualization/vmdk/vmdk.go
@@ -146,7 +146,7 @@ func ParseDiskDescriptor(rs io.ReadSeeker, header Header) (DiskDescriptor, error
 		if !scanner.Scan() {
 			break
 		}
-		line := scanner.Text()
+		line := strings.TrimSpace(scanner.Text())
 		if line == "" {
 			continue
 		}
@@ -161,7 +161,7 @@ func ParseDiskDescriptor(rs io.ReadSeeker, header Header) (DiskDescriptor, error
 			if currentSectionFunc == nil {
 				return DiskDescriptor{}, xerrors.Errorf("invalid descriptor")
 			}
-			err := currentSectionFunc(strings.TrimSpace(line), &descriptor)
+			err := currentSectionFunc(line, &descriptor)
 			if err != nil {
 				return DiskDescriptor{}, err
 			}


### PR DESCRIPTION
Hello,

I'm facing issues parsing VMDKs using Trivy (which uses this library) because of trailing whitespaces in the descriptor file.
See [discussion](https://github.com/aquasecurity/trivy/discussions/10323) for details.

According to [this page](https://github.com/libyal/libvmdk/blob/main/documentation/VMWare%20Virtual%20Disk%20Format%20(VMDK).asciidoc#2-the-descriptor-file) leading and trailing whitespaces are allowed in VMDK descriptor files, so I think we should trim them before processing.

Cheers,
fred