### PR TITLE
Add MonolithicSparse support

### DIFF
--- a/pkg/virtualization/vmdk/const.go
+++ b/pkg/virtualization/vmdk/const.go
@@ -22,12 +22,12 @@ const (
 )
 
 const (
-	StreamOptimized = "streamOptimized"
-	// Custom
-	// MonolithicSparse
+	StreamOptimized  = "streamOptimized"
+	MonolithicSparse = "monolithicSparse"
 	// MonolithicFlat
 	// TwoGbMaxExtentSparse
 	// TwoGbMaxExtentFlat
+	// Custom
 	// FullDevice
 	// PartitionedDevice
 	// VmfsPreallocated

--- a/pkg/virtualization/vmdk/const.go
+++ b/pkg/virtualization/vmdk/const.go
@@ -24,10 +24,10 @@ const (
 const (
 	StreamOptimized  = "streamOptimized"
 	MonolithicSparse = "monolithicSparse"
+	// Custom
 	// MonolithicFlat
 	// TwoGbMaxExtentSparse
 	// TwoGbMaxExtentFlat
-	// Custom
 	// FullDevice
 	// PartitionedDevice
 	// VmfsPreallocated

--- a/pkg/virtualization/vmdk/monolithicsparse.go
+++ b/pkg/virtualization/vmdk/monolithicsparse.go
@@ -34,6 +34,14 @@ func NewMonolithicSparseImage(v VMDK) (*MonolithicSparseImage, error) {
 // parseGrainDirectoryDirect reads GD entries directly from the offset
 // specified in the header, without markers.
 func parseGrainDirectoryDirect(rs io.ReadSeeker, header Header) (GrainDirectory, error) {
+	if header.GdOffset <= 0 {
+		return GrainDirectory{}, xerrors.Errorf("invalid GdOffset: %d", header.GdOffset)
+	}
+	numGDEntries, err := numGrainDirectoryEntries(header)
+	if err != nil {
+		return GrainDirectory{}, err
+	}
+
 	offset := header.GdOffset * Sector
 	off, err := rs.Seek(offset, io.SeekStart)
 	if err != nil {
@@ -42,8 +50,6 @@ func parseGrainDirectoryDirect(rs io.ReadSeeker, header Header) (GrainDirectory,
 	if off != offset {
 		return GrainDirectory{}, xerrors.Errorf(ErrSeekOffsetFormat, off, offset)
 	}
-
-	numGDEntries := numGrainDirectoryEntries(header)
 	entries := make([]Entry, numGDEntries)
 	if err := binary.Read(rs, binary.LittleEndian, entries); err != nil {
 		return GrainDirectory{}, xerrors.Errorf("failed to read grain directory entries: %w", err)
@@ -52,9 +58,12 @@ func parseGrainDirectoryDirect(rs io.ReadSeeker, header Header) (GrainDirectory,
 	return GrainDirectory{Entries: entries}, nil
 }
 
-func numGrainDirectoryEntries(header Header) int64 {
+func numGrainDirectoryEntries(header Header) (int64, error) {
+	if header.GrainSize == 0 || header.NumGTEsPerGT == 0 {
+		return 0, xerrors.Errorf("invalid header: GrainSize=%d NumGTEsPerGT=%d", header.GrainSize, header.NumGTEsPerGT)
+	}
 	numGrains := (header.Capacity + header.GrainSize - 1) / header.GrainSize
-	return (numGrains + int64(header.NumGTEsPerGT) - 1) / int64(header.NumGTEsPerGT)
+	return (numGrains + int64(header.NumGTEsPerGT) - 1) / int64(header.NumGTEsPerGT), nil
 }
 
 // parseGrainTableDirect reads GT entries directly from the offset, without markers.

--- a/pkg/virtualization/vmdk/monolithicsparse.go
+++ b/pkg/virtualization/vmdk/monolithicsparse.go
@@ -1,0 +1,170 @@
+package vmdk
+
+import (
+	"encoding/binary"
+	"io"
+
+	"golang.org/x/xerrors"
+)
+
+var (
+	_ sectionReaderInterface = &MonolithicSparseImage{}
+)
+
+type MonolithicSparseImage struct {
+	VMDK
+
+	GD      GrainDirectory
+	GTCache map[int64]GrainTable
+}
+
+func NewMonolithicSparseImage(v VMDK) (*MonolithicSparseImage, error) {
+	gd, err := parseGrainDirectoryDirect(v.rs, v.Header)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to parse grain directory: %w", err)
+	}
+
+	return &MonolithicSparseImage{
+		VMDK:    v,
+		GD:      gd,
+		GTCache: make(map[int64]GrainTable),
+	}, nil
+}
+
+// parseGrainDirectoryDirect reads GD entries directly from the offset
+// specified in the header, without markers.
+func parseGrainDirectoryDirect(rs io.ReadSeeker, header Header) (GrainDirectory, error) {
+	offset := header.GdOffset * Sector
+	off, err := rs.Seek(offset, io.SeekStart)
+	if err != nil {
+		return GrainDirectory{}, xerrors.Errorf("failed to seek to grain directory: %w", err)
+	}
+	if off != offset {
+		return GrainDirectory{}, xerrors.Errorf(ErrSeekOffsetFormat, off, offset)
+	}
+
+	numGDEntries := numGrainDirectoryEntries(header)
+	entries := make([]Entry, numGDEntries)
+	if err := binary.Read(rs, binary.LittleEndian, entries); err != nil {
+		return GrainDirectory{}, xerrors.Errorf("failed to read grain directory entries: %w", err)
+	}
+
+	return GrainDirectory{Entries: entries}, nil
+}
+
+func numGrainDirectoryEntries(header Header) int64 {
+	numGrains := (header.Capacity + header.GrainSize - 1) / header.GrainSize
+	return (numGrains + int64(header.NumGTEsPerGT) - 1) / int64(header.NumGTEsPerGT)
+}
+
+// parseGrainTableDirect reads GT entries directly from the offset, without markers.
+func (v *MonolithicSparseImage) parseGrainTableDirect(gtOffset int64) (GrainTable, error) {
+	offset := gtOffset * Sector
+	off, err := v.rs.Seek(offset, io.SeekStart)
+	if err != nil {
+		return GrainTable{}, xerrors.Errorf("failed to seek to grain table: %w", err)
+	}
+	if off != offset {
+		return GrainTable{}, xerrors.Errorf(ErrSeekOffsetFormat, off, offset)
+	}
+
+	entries := make([]Entry, v.Header.NumGTEsPerGT)
+	if err := binary.Read(v.rs, binary.LittleEndian, entries); err != nil {
+		return GrainTable{}, xerrors.Errorf("failed to read grain table entries: %w", err)
+	}
+
+	return GrainTable{Entries: entries}, nil
+}
+
+func (v *MonolithicSparseImage) TranslateOffset(off int64) (int64, int64, error) {
+	grain := v.Header.GrainSize * Sector
+	gtSize := grain * int64(v.Header.NumGTEsPerGT)
+
+	gtIndex := off / gtSize
+	if gtIndex >= int64(len(v.GD.Entries)) {
+		return 0, 0, ErrDataNotPresent
+	}
+
+	gtOffset := int64(v.GD.Entries[gtIndex])
+	if gtOffset == 0 {
+		return 0, 0, ErrDataNotPresent
+	}
+
+	gt, ok := v.GTCache[gtOffset]
+	if !ok {
+		var err error
+		gt, err = v.parseGrainTableDirect(gtOffset)
+		if err != nil {
+			return 0, 0, xerrors.Errorf("failed to parse grain table entries: %w", err)
+		}
+		v.GTCache[gtOffset] = gt
+	}
+
+	entryIndex := off % gtSize / grain
+	if entryIndex >= int64(len(gt.Entries)) {
+		return 0, 0, ErrDataNotPresent
+	}
+
+	grainOffset := gt.Entries[entryIndex]
+	if grainOffset == 0 {
+		return 0, 0, ErrDataNotPresent
+	}
+
+	dataOffset := off % gtSize % grain
+	return int64(grainOffset), dataOffset, nil
+}
+
+func (v *MonolithicSparseImage) read(grainOffset int64) ([]byte, error) {
+	cacheKey := grainOffsetCacheKey(grainOffset)
+	data, ok := v.cache.Get(cacheKey)
+	if ok {
+		return data, nil
+	}
+
+	offset := grainOffset * Sector
+	off, err := v.rs.Seek(offset, io.SeekStart)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to seek to grain data: %w", err)
+	}
+	if off != offset {
+		return nil, xerrors.Errorf(ErrSeekOffsetFormat, off, offset)
+	}
+
+	grainDataSize := v.Header.GrainSize * Sector
+	buf := make([]byte, grainDataSize)
+	n, err := io.ReadFull(v.rs, buf)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to read grain data: %w", err)
+	}
+	if int64(n) != grainDataSize {
+		return nil, xerrors.Errorf(ErrReadSizeFormat, n, grainDataSize)
+	}
+
+	v.cache.Add(cacheKey, buf)
+	return buf, nil
+}
+
+func (v *MonolithicSparseImage) ReadAt(p []byte, off int64) (n int, err error) {
+	if len(p) != int(Sector) {
+		return 0, xerrors.Errorf("invalid byte length %d, required %d bytes length", len(p), Sector)
+	}
+	grainOffset, dataOffset, err := v.TranslateOffset(off)
+	if err == ErrDataNotPresent {
+		for i := range p {
+			p[i] = 0
+		}
+		return int(Sector), nil
+	} else if err != nil {
+		return 0, xerrors.Errorf("failed to translate offset: %w", err)
+	}
+
+	data, err := v.read(grainOffset)
+	if err != nil {
+		return 0, xerrors.Errorf("failed to read data: %w", err)
+	}
+
+	if v.Header.GrainSize*Sector-dataOffset < Sector {
+		return copy(p, data[dataOffset:]), nil
+	}
+	return copy(p, data[dataOffset:dataOffset+Sector]), nil
+}

--- a/pkg/virtualization/vmdk/streamoptimized.go
+++ b/pkg/virtualization/vmdk/streamoptimized.go
@@ -205,14 +205,6 @@ func NewStreamOptimizedImage(v VMDK) (*StreamOptimizedImage, error) {
 	}, nil
 }
 
-func (v *StreamOptimizedImage) Size() int64 {
-	var size int64
-	for _, extent := range v.DiskDescriptor.Extents {
-		size += extent.Size
-	}
-	return size * Sector
-}
-
 func grainOffsetCacheKey(n int64) string {
 	return fmt.Sprintf("vmdk:%d", n)
 }
@@ -253,6 +245,9 @@ func (v *StreamOptimizedImage) ReadAt(p []byte, off int64) (n int, err error) {
 	}
 	grainOffset, dataOffset, err := v.TranslateOffset(off)
 	if err == ErrDataNotPresent {
+		for i := range p {
+			p[i] = 0
+		}
 		return int(Sector), nil
 	} else if err != nil {
 		return 0, xerrors.Errorf("failed to translate offset: %w", err)

--- a/pkg/virtualization/vmdk/vmdk.go
+++ b/pkg/virtualization/vmdk/vmdk.go
@@ -161,7 +161,7 @@ func ParseDiskDescriptor(rs io.ReadSeeker, header Header) (DiskDescriptor, error
 			if currentSectionFunc == nil {
 				return DiskDescriptor{}, xerrors.Errorf("invalid descriptor")
 			}
-			err := currentSectionFunc(line, &descriptor)
+			err := currentSectionFunc(strings.TrimSpace(line), &descriptor)
 			if err != nil {
 				return DiskDescriptor{}, err
 			}
@@ -201,8 +201,7 @@ func parseExtentDescription(line string, dd *DiskDescriptor) error {
 	return nil
 }
 
-func parseDiskDescriptorFile(rawLine string, dd *DiskDescriptor) error {
-	line := strings.TrimSpace(rawLine)
+func parseDiskDescriptorFile(line string, dd *DiskDescriptor) error {
 	switch {
 	case strings.HasPrefix(line, "version="):
 		vstr := strings.TrimPrefix(line, "version=")

--- a/pkg/virtualization/vmdk/vmdk.go
+++ b/pkg/virtualization/vmdk/vmdk.go
@@ -201,7 +201,8 @@ func parseExtentDescription(line string, dd *DiskDescriptor) error {
 	return nil
 }
 
-func parseDiskDescriptorFile(line string, dd *DiskDescriptor) error {
+func parseDiskDescriptorFile(rawLine string, dd *DiskDescriptor) error {
+	line := strings.TrimSpace(rawLine)
 	switch {
 	case strings.HasPrefix(line, "version="):
 		vstr := strings.TrimPrefix(line, "version=")

--- a/pkg/virtualization/vmdk/vmdk.go
+++ b/pkg/virtualization/vmdk/vmdk.go
@@ -120,6 +120,7 @@ func Open(rs io.ReadSeeker, cache Cache[string, []byte]) (*io.SectionReader, err
 		return nil, xerrors.Errorf("failed to parse disk descriptor: %w", err)
 	}
 	if len(v.DiskDescriptor.Extents) != 1 {
+		// TODO: Support divided image (e.g. image1.vmdk, image2.vmdk, ... )
 		return nil, ErrUnSupportedDividedImage
 	}
 

--- a/pkg/virtualization/vmdk/vmdk.go
+++ b/pkg/virtualization/vmdk/vmdk.go
@@ -60,6 +60,14 @@ type VMDK struct {
 	rs io.ReadSeeker
 }
 
+func (v *VMDK) Size() int64 {
+	var size int64
+	for _, extent := range v.DiskDescriptor.Extents {
+		size += extent.Size
+	}
+	return size * Sector
+}
+
 type DiskDescriptor struct {
 	Version    int
 	CID        string
@@ -112,7 +120,6 @@ func Open(rs io.ReadSeeker, cache Cache[string, []byte]) (*io.SectionReader, err
 		return nil, xerrors.Errorf("failed to parse disk descriptor: %w", err)
 	}
 	if len(v.DiskDescriptor.Extents) != 1 {
-		// TODO: Support divided image (e.g. image1.vmdk, image2.vmdk, ... )
 		return nil, ErrUnSupportedDividedImage
 	}
 
@@ -122,6 +129,11 @@ func Open(rs io.ReadSeeker, cache Cache[string, []byte]) (*io.SectionReader, err
 		r, err = NewStreamOptimizedImage(v)
 		if err != nil {
 			return nil, xerrors.Errorf("failed to new stream-optimized image: %w", err)
+		}
+	case MonolithicSparse:
+		r, err = NewMonolithicSparseImage(v)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to new monolithic-sparse image: %w", err)
 		}
 	default:
 		return nil, xerrors.Errorf("%s: %w", v.DiskDescriptor.CreateType, ErrUnSupportedType)
@@ -139,35 +151,7 @@ func ParseDiskDescriptor(rs io.ReadSeeker, header Header) (DiskDescriptor, error
 		return DiskDescriptor{}, xerrors.Errorf(ErrSeekOffsetFormat, i, header.DescriptorOffset*Sector)
 	}
 
-	var descriptor DiskDescriptor
-	scanner := bufio.NewScanner(io.LimitReader(rs, Sector*header.DescriptorSize))
-	var currentSectionFunc func(string, *DiskDescriptor) error
-	for {
-		if !scanner.Scan() {
-			break
-		}
-		line := strings.TrimSpace(scanner.Text())
-		if line == "" {
-			continue
-		}
-		switch strings.ToLower(strings.TrimSpace(strings.TrimPrefix(line, "#"))) {
-		case SectionDiskDescriptorFile:
-			currentSectionFunc = parseDiskDescriptorFile
-		case SectionExtentDescription:
-			currentSectionFunc = parseExtentDescription
-		case SectionDiskDataBase, SectionDDB:
-			currentSectionFunc = parseDiskDataBase
-		default:
-			if currentSectionFunc == nil {
-				return DiskDescriptor{}, xerrors.Errorf("invalid descriptor")
-			}
-			err := currentSectionFunc(line, &descriptor)
-			if err != nil {
-				return DiskDescriptor{}, err
-			}
-		}
-	}
-	return descriptor, nil
+	return parseDescriptorLines(bufio.NewScanner(io.LimitReader(rs, Sector*header.DescriptorSize)))
 }
 
 func parseDiskDataBase(line string, dd *DiskDescriptor) error {
@@ -218,4 +202,41 @@ func parseDiskDescriptorFile(line string, dd *DiskDescriptor) error {
 		dd.ParentCID = strings.TrimPrefix(line, "parentCID=")
 	}
 	return nil
+}
+
+// ParseTextDescriptor parses a VMDK descriptor from a text reader.
+// This is useful for testing descriptor parsing independently.
+func ParseTextDescriptor(r io.Reader) (DiskDescriptor, error) {
+	return parseDescriptorLines(bufio.NewScanner(r))
+}
+
+func parseDescriptorLines(scanner *bufio.Scanner) (DiskDescriptor, error) {
+	var descriptor DiskDescriptor
+	var currentSectionFunc func(string, *DiskDescriptor) error
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		switch strings.ToLower(strings.TrimSpace(strings.TrimPrefix(line, "#"))) {
+		case SectionDiskDescriptorFile:
+			currentSectionFunc = parseDiskDescriptorFile
+		case SectionExtentDescription:
+			currentSectionFunc = parseExtentDescription
+		case SectionDiskDataBase, SectionDDB:
+			currentSectionFunc = parseDiskDataBase
+		default:
+			if currentSectionFunc == nil {
+				return DiskDescriptor{}, xerrors.Errorf("invalid descriptor")
+			}
+			err := currentSectionFunc(line, &descriptor)
+			if err != nil {
+				return DiskDescriptor{}, err
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return DiskDescriptor{}, xerrors.Errorf("failed to scan descriptor: %w", err)
+	}
+	return descriptor, nil
 }

--- a/pkg/virtualization/vmdk/vmdk.go
+++ b/pkg/virtualization/vmdk/vmdk.go
@@ -161,7 +161,7 @@ func ParseDiskDescriptor(rs io.ReadSeeker, header Header) (DiskDescriptor, error
 			if currentSectionFunc == nil {
 				return DiskDescriptor{}, xerrors.Errorf("invalid descriptor")
 			}
-			err := currentSectionFunc(strings.TrimSpace(line), &descriptor)
+			err := currentSectionFunc(line, &descriptor)
 			if err != nil {
 				return DiskDescriptor{}, err
 			}

--- a/pkg/virtualization/vmdk/vmdk.go
+++ b/pkg/virtualization/vmdk/vmdk.go
@@ -204,12 +204,6 @@ func parseDiskDescriptorFile(line string, dd *DiskDescriptor) error {
 	return nil
 }
 
-// ParseTextDescriptor parses a VMDK descriptor from a text reader.
-// This is useful for testing descriptor parsing independently.
-func ParseTextDescriptor(r io.Reader) (DiskDescriptor, error) {
-	return parseDescriptorLines(bufio.NewScanner(r))
-}
-
 func parseDescriptorLines(scanner *bufio.Scanner) (DiskDescriptor, error) {
 	var descriptor DiskDescriptor
 	var currentSectionFunc func(string, *DiskDescriptor) error

--- a/pkg/virtualization/vmdk/vmdk_test.go
+++ b/pkg/virtualization/vmdk/vmdk_test.go
@@ -205,3 +205,32 @@ func TestParseTextDescriptorWithWhitespace(t *testing.T) {
 		t.Errorf("Extent.Name = %s, want test.vmdk", ext.Name)
 	}
 }
+
+func TestNewMonolithicSparseImageInvalidHeader(t *testing.T) {
+	tests := []struct {
+		name   string
+		header vmdk.Header
+	}{
+		{
+			name:   "GrainSize is zero",
+			header: vmdk.Header{GrainSize: 0, NumGTEsPerGT: 512, GdOffset: 1, Capacity: 128},
+		},
+		{
+			name:   "NumGTEsPerGT is zero",
+			header: vmdk.Header{GrainSize: 128, NumGTEsPerGT: 0, GdOffset: 1, Capacity: 128},
+		},
+		{
+			name:   "GdOffset is zero",
+			header: vmdk.Header{GrainSize: 128, NumGTEsPerGT: 512, GdOffset: 0, Capacity: 128},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := vmdk.VMDK{Header: tt.header}
+			_, err := vmdk.NewMonolithicSparseImage(v)
+			if err == nil {
+				t.Fatal("NewMonolithicSparseImage() should return error for invalid header")
+			}
+		})
+	}
+}

--- a/pkg/virtualization/vmdk/vmdk_test.go
+++ b/pkg/virtualization/vmdk/vmdk_test.go
@@ -3,7 +3,6 @@ package vmdk_test
 import (
 	"os"
 	"reflect"
-	"strings"
 	"testing"
 
 	"github.com/masahiro331/go-vmdk-parser/pkg/virtualization/vmdk"
@@ -155,54 +154,6 @@ func TestOpenMonolithicSparseZeroFill(t *testing.T) {
 			t.Errorf("ReadAt() byte[%d] = 0x%02x, want 0x00 (sparse region must be zero-filled)", i, b)
 			break
 		}
-	}
-}
-
-func TestParseTextDescriptorWithWhitespace(t *testing.T) {
-	// Descriptor with leading/trailing whitespace on lines
-	// See: https://github.com/masahiro331/go-vmdk-parser/pull/7
-	// See: https://github.com/aquasecurity/trivy/discussions/10323
-	descriptor := "  # Disk DescriptorFile  \n" +
-		"  version=1  \n" +
-		"  CID=12345678  \n" +
-		"  parentCID=ffffffff  \n" +
-		"  createType=\"monolithicSparse\"  \n" +
-		"\n" +
-		"  # Extent description  \n" +
-		"  RW 128 SPARSE \"test.vmdk\"  \n" +
-		"\n" +
-		"  # The Disk Data Base  \n" +
-		"  ddb.virtualHWVersion = \"4\"  \n"
-
-	dd, err := vmdk.ParseTextDescriptor(strings.NewReader(descriptor))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if dd.Version != 1 {
-		t.Errorf("Version = %d, want 1", dd.Version)
-	}
-	if dd.CID != "12345678" {
-		t.Errorf("CID = %s, want 12345678", dd.CID)
-	}
-	if dd.CreateType != "monolithicSparse" {
-		t.Errorf("CreateType = %s, want monolithicSparse", dd.CreateType)
-	}
-	if len(dd.Extents) != 1 {
-		t.Fatalf("len(Extents) = %d, want 1", len(dd.Extents))
-	}
-	ext := dd.Extents[0]
-	if ext.Mode != "RW" {
-		t.Errorf("Extent.Mode = %s, want RW", ext.Mode)
-	}
-	if ext.Size != 128 {
-		t.Errorf("Extent.Size = %d, want 128", ext.Size)
-	}
-	if ext.Type != "SPARSE" {
-		t.Errorf("Extent.Type = %s, want SPARSE", ext.Type)
-	}
-	if ext.Name != "test.vmdk" {
-		t.Errorf("Extent.Name = %s, want test.vmdk", ext.Name)
 	}
 }
 

--- a/pkg/virtualization/vmdk/vmdk_test.go
+++ b/pkg/virtualization/vmdk/vmdk_test.go
@@ -3,6 +3,7 @@ package vmdk_test
 import (
 	"os"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/masahiro331/go-vmdk-parser/pkg/virtualization/vmdk"
@@ -86,5 +87,121 @@ func TestParseDiskDescriptor(t *testing.T) {
 				t.Errorf("ParseDiskDescriptor() got = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestOpenMonolithicSparse(t *testing.T) {
+	// Built by "qemu-img create -f vmdk vmdk-monolith.img 65536" command
+	f, err := os.Open("testdata/vmdk-monolith.img")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	sr, err := vmdk.Open(f, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Disk is 128 sectors = 65536 bytes
+	if sr.Size() != 65536 {
+		t.Errorf("Size() = %d, want 65536", sr.Size())
+	}
+
+	// The disk is empty (all sparse), so reading should return zeros
+	buf := make([]byte, 512)
+	n, err := sr.ReadAt(buf, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 512 {
+		t.Errorf("ReadAt() n = %d, want 512", n)
+	}
+	for i, b := range buf {
+		if b != 0 {
+			t.Errorf("ReadAt() byte[%d] = %d, want 0", i, b)
+			break
+		}
+	}
+}
+
+func TestOpenMonolithicSparseZeroFill(t *testing.T) {
+	f, err := os.Open("testdata/vmdk-monolith.img")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	sr, err := vmdk.Open(f, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Pre-fill buffer with non-zero data to verify sparse regions are zeroed
+	buf := make([]byte, 512)
+	for i := range buf {
+		buf[i] = 0xFF
+	}
+
+	n, err := sr.ReadAt(buf, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 512 {
+		t.Errorf("ReadAt() n = %d, want 512", n)
+	}
+	for i, b := range buf {
+		if b != 0 {
+			t.Errorf("ReadAt() byte[%d] = 0x%02x, want 0x00 (sparse region must be zero-filled)", i, b)
+			break
+		}
+	}
+}
+
+func TestParseTextDescriptorWithWhitespace(t *testing.T) {
+	// Descriptor with leading/trailing whitespace on lines
+	// See: https://github.com/masahiro331/go-vmdk-parser/pull/7
+	// See: https://github.com/aquasecurity/trivy/discussions/10323
+	descriptor := "  # Disk DescriptorFile  \n" +
+		"  version=1  \n" +
+		"  CID=12345678  \n" +
+		"  parentCID=ffffffff  \n" +
+		"  createType=\"monolithicSparse\"  \n" +
+		"\n" +
+		"  # Extent description  \n" +
+		"  RW 128 SPARSE \"test.vmdk\"  \n" +
+		"\n" +
+		"  # The Disk Data Base  \n" +
+		"  ddb.virtualHWVersion = \"4\"  \n"
+
+	dd, err := vmdk.ParseTextDescriptor(strings.NewReader(descriptor))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if dd.Version != 1 {
+		t.Errorf("Version = %d, want 1", dd.Version)
+	}
+	if dd.CID != "12345678" {
+		t.Errorf("CID = %s, want 12345678", dd.CID)
+	}
+	if dd.CreateType != "monolithicSparse" {
+		t.Errorf("CreateType = %s, want monolithicSparse", dd.CreateType)
+	}
+	if len(dd.Extents) != 1 {
+		t.Fatalf("len(Extents) = %d, want 1", len(dd.Extents))
+	}
+	ext := dd.Extents[0]
+	if ext.Mode != "RW" {
+		t.Errorf("Extent.Mode = %s, want RW", ext.Mode)
+	}
+	if ext.Size != 128 {
+		t.Errorf("Extent.Size = %d, want 128", ext.Size)
+	}
+	if ext.Type != "SPARSE" {
+		t.Errorf("Extent.Type = %s, want SPARSE", ext.Type)
+	}
+	if ext.Name != "test.vmdk" {
+		t.Errorf("Extent.Name = %s, want test.vmdk", ext.Name)
 	}
 }


### PR DESCRIPTION
## Summary

- closes #3

Add support for MonolithicSparse VMDK format, the default output format of VMware Workstation and qemu-img. 

This PR is based on #7 (trim whitespace in descriptor parsing). If #7 is merged first, this PR can be rebased to exclude those commits.

## Changes

- Add `MonolithicSparseImage` type that reads non-compressed sparse extents using direct GD/GT offset lookup (no markers)
- Add `MonolithicSparse` case to `Open()`
- Move `Size()` from `StreamOptimizedImage` to `VMDK` base struct to share with `MonolithicSparseImage`
- Extract `parseDescriptorLines()` from `ParseDiskDescriptor` and add TrimSpace / `scanner.Err()` check
- Zero-fill buffer on `ErrDataNotPresent` in both `MonolithicSparseImage.ReadAt` and `StreamOptimizedImage.ReadAt`
- Validate `GdOffset`, `GrainSize`, and `NumGTEsPerGT` in `MonolithicSparseImage` to prevent panic on corrupted headers
- Add MonolithicSparse integration tests using existing test data (`vmdk-monolith.img`)

---

## 概要

MonolithicSparse VMDK フォーマットのサポートを追加します。VMware Workstation や qemu-img のデフォルト出力形式です。

この PR は #7（ Descriptor パースの空白処理修正）をベースにしています。#7 が先にマージされた場合は、リベースしてそのコミットを除外できます。

## 変更内容

- マーカーなしの GD/GT オフセット直接参照で非圧縮 Sparse Extent を読み取る `MonolithicSparseImage` 型を追加
- `Open()` に `MonolithicSparse` ケースを追加
- `Size()` を `StreamOptimizedImage` から `VMDK` ベース構造体に移動し、`MonolithicSparseImage` と共有
- `parseDescriptorLines()` を `ParseDiskDescriptor` から抽出し、TrimSpace / `scanner.Err()` チェックを追加
- `MonolithicSparseImage.ReadAt` と `StreamOptimizedImage.ReadAt` の両方で、`ErrDataNotPresent` 時にバッファをゼロクリア
- `MonolithicSparseImage` で `GdOffset`、`GrainSize`、`NumGTEsPerGT` をバリデーションし、破損ヘッダでの panic を防止
- 既存のテストデータ（`vmdk-monolith.img`）を使った MonolithicSparse の統合テストを追加