### PR TITLE
Support arbitrary buffer sizes in ReadAt

### DIFF
--- a/pkg/virtualization/vmdk/monolithicsparse.go
+++ b/pkg/virtualization/vmdk/monolithicsparse.go
@@ -153,27 +153,10 @@ func (v *MonolithicSparseImage) read(grainOffset int64) ([]byte, error) {
 	return buf, nil
 }
 
-func (v *MonolithicSparseImage) ReadAt(p []byte, off int64) (n int, err error) {
-	if len(p) != int(Sector) {
-		return 0, xerrors.Errorf("invalid byte length %d, required %d bytes length", len(p), Sector)
-	}
-	grainOffset, dataOffset, err := v.TranslateOffset(off)
-	if err == ErrDataNotPresent {
-		for i := range p {
-			p[i] = 0
-		}
-		return int(Sector), nil
-	} else if err != nil {
-		return 0, xerrors.Errorf("failed to translate offset: %w", err)
-	}
+func (v *MonolithicSparseImage) grainDataSize() int64 {
+	return v.Header.GrainSize * Sector
+}
 
-	data, err := v.read(grainOffset)
-	if err != nil {
-		return 0, xerrors.Errorf("failed to read data: %w", err)
-	}
-
-	if v.Header.GrainSize*Sector-dataOffset < Sector {
-		return copy(p, data[dataOffset:]), nil
-	}
-	return copy(p, data[dataOffset:dataOffset+Sector]), nil
+func (v *MonolithicSparseImage) ReadAt(p []byte, off int64) (int, error) {
+	return readAt(v, p, off)
 }

--- a/pkg/virtualization/vmdk/streamoptimized.go
+++ b/pkg/virtualization/vmdk/streamoptimized.go
@@ -239,30 +239,12 @@ func (v *StreamOptimizedImage) read(grainOffset int64) ([]byte, error) {
 	return decompressedData, nil
 }
 
-func (v *StreamOptimizedImage) ReadAt(p []byte, off int64) (n int, err error) {
-	if len(p) != int(Sector) {
-		return 0, xerrors.Errorf("invalid byte length %d, required %d bytes length", len(p), Sector)
-	}
-	grainOffset, dataOffset, err := v.TranslateOffset(off)
-	if err == ErrDataNotPresent {
-		for i := range p {
-			p[i] = 0
-		}
-		return int(Sector), nil
-	} else if err != nil {
-		return 0, xerrors.Errorf("failed to translate offset: %w", err)
-	}
+func (v *StreamOptimizedImage) grainDataSize() int64 {
+	return v.Header.GrainSize * Sector
+}
 
-	data, err := v.read(grainOffset)
-	if err != nil {
-		return 0, xerrors.Errorf("failed to read data: %w", err)
-	}
-
-	if v.Header.GrainSize*Sector-dataOffset < Sector {
-		return copy(p, data[dataOffset:]), nil
-	} else {
-		return copy(p, data[dataOffset:dataOffset+Sector]), nil
-	}
+func (v *StreamOptimizedImage) ReadAt(p []byte, off int64) (int, error) {
+	return readAt(v, p, off)
 }
 
 func (v *StreamOptimizedImage) readGrain(grainOffset int64) ([]byte, error) {

--- a/pkg/virtualization/vmdk/vmdk.go
+++ b/pkg/virtualization/vmdk/vmdk.go
@@ -80,8 +80,9 @@ func readAt(gr grainReader, p []byte, off int64) (int, error) {
 			if currentOff+zeroLen > totalSize {
 				zeroLen = totalSize - currentOff
 			}
-			for i := int64(0); i < zeroLen; i++ {
-				p[totalRead+int(i)] = 0
+			zeroSlice := p[totalRead : totalRead+int(zeroLen)]
+			for i := range zeroSlice {
+				zeroSlice[i] = 0
 			}
 			totalRead += int(zeroLen)
 			continue

--- a/pkg/virtualization/vmdk/vmdk.go
+++ b/pkg/virtualization/vmdk/vmdk.go
@@ -95,6 +95,9 @@ func readAt(gr grainReader, p []byte, off int64) (int, error) {
 		}
 
 		available := int64(len(data)) - dataOff
+		if available <= 0 {
+			return totalRead, xerrors.Errorf("invalid data offset %d for grain size %d", dataOff, len(data))
+		}
 		need := int64(len(p) - totalRead)
 		if need > available {
 			need = available

--- a/pkg/virtualization/vmdk/vmdk.go
+++ b/pkg/virtualization/vmdk/vmdk.go
@@ -45,6 +45,69 @@ type sectionReaderInterface interface {
 	Size() int64
 }
 
+// grainReader abstracts grain-level read operations shared by
+// StreamOptimizedImage and MonolithicSparseImage.
+type grainReader interface {
+	TranslateOffset(off int64) (grainOffset int64, dataOffset int64, err error)
+	read(grainOffset int64) ([]byte, error)
+	grainDataSize() int64
+	Size() int64
+}
+
+// readAt implements io.ReaderAt for any grainReader by looping over grains.
+func readAt(gr grainReader, p []byte, off int64) (int, error) {
+	totalSize := gr.Size()
+	if off >= totalSize {
+		return 0, io.EOF
+	}
+
+	grain := gr.grainDataSize()
+	totalRead := 0
+	for totalRead < len(p) {
+		currentOff := off + int64(totalRead)
+		if currentOff >= totalSize {
+			return totalRead, io.EOF
+		}
+
+		grainOff, dataOff, err := gr.TranslateOffset(currentOff)
+		if err == ErrDataNotPresent {
+			// Zero-fill up to next grain boundary or remaining buffer
+			zeroLen := grain - (currentOff % grain)
+			remaining := int64(len(p) - totalRead)
+			if zeroLen > remaining {
+				zeroLen = remaining
+			}
+			if currentOff+zeroLen > totalSize {
+				zeroLen = totalSize - currentOff
+			}
+			for i := int64(0); i < zeroLen; i++ {
+				p[totalRead+int(i)] = 0
+			}
+			totalRead += int(zeroLen)
+			continue
+		} else if err != nil {
+			return totalRead, xerrors.Errorf("failed to translate offset: %w", err)
+		}
+
+		data, err := gr.read(grainOff)
+		if err != nil {
+			return totalRead, xerrors.Errorf("failed to read data: %w", err)
+		}
+
+		available := int64(len(data)) - dataOff
+		need := int64(len(p) - totalRead)
+		if need > available {
+			need = available
+		}
+		if currentOff+need > totalSize {
+			need = totalSize - currentOff
+		}
+		copy(p[totalRead:], data[dataOff:dataOff+need])
+		totalRead += int(need)
+	}
+	return totalRead, nil
+}
+
 var (
 	_                          sectionReaderInterface = &StreamOptimizedImage{}
 	ErrUnSupportedDividedImage                        = xerrors.New("divided images are not supported")

--- a/pkg/virtualization/vmdk/vmdk_test.go
+++ b/pkg/virtualization/vmdk/vmdk_test.go
@@ -1,6 +1,7 @@
 package vmdk_test
 
 import (
+	"io"
 	"os"
 	"reflect"
 	"testing"
@@ -152,6 +153,115 @@ func TestOpenMonolithicSparseZeroFill(t *testing.T) {
 	for i, b := range buf {
 		if b != 0 {
 			t.Errorf("ReadAt() byte[%d] = 0x%02x, want 0x00 (sparse region must be zero-filled)", i, b)
+			break
+		}
+	}
+}
+
+func TestReadAtVariousBufferSizes(t *testing.T) {
+	// vmdk-monolith.img is a 65536-byte (128 sectors) empty monolithicSparse image
+	f, err := os.Open("testdata/vmdk-monolith.img")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	sr, err := vmdk.Open(f, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sizes := []int{1, 256, 512, 1024, 4096, 65536}
+	for _, size := range sizes {
+		buf := make([]byte, size)
+		// Pre-fill with non-zero to verify zero-fill
+		for i := range buf {
+			buf[i] = 0xFF
+		}
+
+		n, err := sr.ReadAt(buf, 0)
+		if err != nil {
+			t.Fatalf("ReadAt(size=%d) err = %v", size, err)
+		}
+		if n != size {
+			t.Fatalf("ReadAt(size=%d) n = %d, want %d", size, n, size)
+		}
+		for i, b := range buf {
+			if b != 0 {
+				t.Errorf("ReadAt(size=%d) byte[%d] = 0x%02x, want 0x00", size, i, b)
+				break
+			}
+		}
+	}
+}
+
+func TestReadAtPartialEOF(t *testing.T) {
+	f, err := os.Open("testdata/vmdk-monolith.img")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	sr, err := vmdk.Open(f, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Read 1024 bytes starting at offset 65024 (512 bytes before EOF)
+	buf := make([]byte, 1024)
+	n, err := sr.ReadAt(buf, 65024)
+	if err != io.EOF {
+		t.Fatalf("ReadAt(65024) err = %v, want io.EOF", err)
+	}
+	if n != 512 {
+		t.Fatalf("ReadAt(65024) n = %d, want 512", n)
+	}
+}
+
+func TestReadAtBeyondEOF(t *testing.T) {
+	f, err := os.Open("testdata/vmdk-monolith.img")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	sr, err := vmdk.Open(f, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	buf := make([]byte, 512)
+	n, err := sr.ReadAt(buf, 65536)
+	if err != io.EOF {
+		t.Fatalf("ReadAt(65536) err = %v, want io.EOF", err)
+	}
+	if n != 0 {
+		t.Fatalf("ReadAt(65536) n = %d, want 0", n)
+	}
+}
+
+func TestReadAll(t *testing.T) {
+	f, err := os.Open("testdata/vmdk-monolith.img")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	sr, err := vmdk.Open(f, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := io.ReadAll(io.NewSectionReader(sr, 0, sr.Size()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(data) != 65536 {
+		t.Fatalf("ReadAll() len = %d, want 65536", len(data))
+	}
+	for i, b := range data {
+		if b != 0 {
+			t.Errorf("ReadAll() byte[%d] = 0x%02x, want 0x00", i, b)
 			break
 		}
 	}


### PR DESCRIPTION
## Summary

The current `ReadAt` implementation only accepts exactly 512-byte buffers, returning an error for any other size. This violates the `io.ReaderAt` contract, which requires support for arbitrary buffer sizes.

- Introduces a `grainReader` interface and shared `readAt` helper that loops over grain boundaries, handling multi-grain reads, zero-fill for unallocated regions, and proper EOF semantics
- Replaces the 512-byte-only `ReadAt` in both `StreamOptimizedImage` and `MonolithicSparseImage` with the shared implementation
- Enables standard library usage such as `io.ReadAll` and `io.SectionReader` to work correctly

## Note

This PR may conflict with #4 (`feat/thread_safe`) as both modify `ReadAt`-related code in `streamoptimized.go`. 

## Test plan

- [x] `TestReadAtVariousBufferSizes` — verifies buffer sizes: 1, 256, 512, 1024, 4096, 65536 bytes
- [x] `TestReadAtPartialEOF` — reads across EOF boundary, verifies partial read + `io.EOF`
- [x] `TestReadAtBeyondEOF` — reads at offset == size, verifies 0 bytes + `io.EOF`
- [x] `TestReadAll` — `io.ReadAll` over the full image via `io.SectionReader`
- [x] Existing tests pass

--- 

## 概要

現在の `ReadAt` 実装は 512 バイトのバッファのみ受け付け、それ以外のサイズではエラーを返します。これは任意サイズのバッファをサポートすべき `io.ReaderAt` の契約に違反しています。

- `grainReader` インターフェースと共通の `readAt` ヘルパーを導入し、Grain 境界をまたぐ読み取り、未割り当て領域のゼロフィル、正しい EOF セマンティクスを処理
- `StreamOptimizedImage` と `MonolithicSparseImage` 両方の 512 バイト専用 `ReadAt` を共通実装に置き換え
- `io.ReadAll` や `io.SectionReader` などの標準ライブラリが正しく動作するように

## 備考

#4 (`feat/thread_safe`) と `streamoptimized.go` の `ReadAt` 関連コードでコンフリクトする可能性があります。

## テスト

- [x] `TestReadAtVariousBufferSizes` — バッファサイズ 1, 256, 512, 1024, 4096, 65536 バイトで検証
- [x] `TestReadAtPartialEOF` — EOF 境界をまたぐ読み取り、部分読み取り + `io.EOF` を検証
- [x] `TestReadAtBeyondEOF` — offset == size での読み取り、0 バイト + `io.EOF` を検証
- [x] `TestReadAll` — `io.SectionReader` 経由で `io.ReadAll` による全体読み取り
- [x] 既存テスト通過