### PR TITLE
Improve StreamOptimized robustness and spec compliance

### DIFF
--- a/pkg/virtualization/vmdk/const.go
+++ b/pkg/virtualization/vmdk/const.go
@@ -12,6 +12,14 @@ const (
 
 	// Sparse extent header flags
 	FlagUseZeroedGrainTableEntry = int32(0x00000004)
+
+	// Incompatible flags (upper 16 bits)
+	FlagCompressed  = uint32(0x00010000)
+	FlagEmbeddedLBA = uint32(0x00020000)
+	// Mask for all known incompatible flags
+	knownIncompatFlags = FlagCompressed | FlagEmbeddedLBA
+	// Mask for incompatible flag bits
+	incompatFlagsMask = uint32(0xFFFF0000)
 )
 
 const (

--- a/pkg/virtualization/vmdk/const.go
+++ b/pkg/virtualization/vmdk/const.go
@@ -11,15 +11,14 @@ const (
 	KDMV = uint32(0x564d444b)
 
 	// Sparse extent header flags
-	FlagUseZeroedGrainTableEntry = int32(0x00000004)
+	FlagUseZeroedGrainTableEntry = uint32(0x00000004)
 
 	// Incompatible flags (upper 16 bits)
 	FlagCompressed  = uint32(0x00010000)
 	FlagEmbeddedLBA = uint32(0x00020000)
-	// Mask for all known incompatible flags
+
 	knownIncompatFlags = FlagCompressed | FlagEmbeddedLBA
-	// Mask for incompatible flag bits
-	incompatFlagsMask = uint32(0xFFFF0000)
+	incompatFlagsMask  = uint32(0xFFFF0000)
 )
 
 const (

--- a/pkg/virtualization/vmdk/const.go
+++ b/pkg/virtualization/vmdk/const.go
@@ -9,6 +9,15 @@ const (
 
 	// COWD = uint32(0x434f5744)
 	KDMV = uint32(0x564d444b)
+
+	// Sparse extent header flags
+	FlagUseZeroedGrainTableEntry = int32(0x00000004)
+)
+
+const (
+	// GTE special values
+	GTEEmpty  = Entry(0) // Sparse: no data allocated
+	GTEZeroed = Entry(1) // Zeroed grain (only when FlagUseZeroedGrainTableEntry is set)
 )
 
 const (

--- a/pkg/virtualization/vmdk/monolithicsparse.go
+++ b/pkg/virtualization/vmdk/monolithicsparse.go
@@ -115,11 +115,7 @@ func (v *MonolithicSparseImage) TranslateOffset(off int64) (int64, int64, error)
 	}
 
 	grainOffset := gt.Entries[entryIndex]
-	if grainOffset == GTEEmpty {
-		return 0, 0, ErrDataNotPresent
-	}
-	// Per VMDK spec, GTE=1 is a valid sector offset when FlagUseZeroedGrainTableEntry is not set
-	if grainOffset == GTEZeroed && uint32(v.Header.Flag)&FlagUseZeroedGrainTableEntry != 0 {
+	if isGTEAbsent(grainOffset, uint32(v.Header.Flag)) {
 		return 0, 0, ErrDataNotPresent
 	}
 

--- a/pkg/virtualization/vmdk/monolithicsparse.go
+++ b/pkg/virtualization/vmdk/monolithicsparse.go
@@ -118,7 +118,8 @@ func (v *MonolithicSparseImage) TranslateOffset(off int64) (int64, int64, error)
 	if grainOffset == GTEEmpty {
 		return 0, 0, ErrDataNotPresent
 	}
-	if grainOffset == GTEZeroed && v.Header.Flag&FlagUseZeroedGrainTableEntry != 0 {
+	// Per VMDK spec, GTE=1 is a valid sector offset when FlagUseZeroedGrainTableEntry is not set
+	if grainOffset == GTEZeroed && uint32(v.Header.Flag)&FlagUseZeroedGrainTableEntry != 0 {
 		return 0, 0, ErrDataNotPresent
 	}
 

--- a/pkg/virtualization/vmdk/monolithicsparse.go
+++ b/pkg/virtualization/vmdk/monolithicsparse.go
@@ -115,7 +115,10 @@ func (v *MonolithicSparseImage) TranslateOffset(off int64) (int64, int64, error)
 	}
 
 	grainOffset := gt.Entries[entryIndex]
-	if grainOffset == 0 {
+	if grainOffset == GTEEmpty {
+		return 0, 0, ErrDataNotPresent
+	}
+	if grainOffset == GTEZeroed && v.Header.Flag&FlagUseZeroedGrainTableEntry != 0 {
 		return 0, 0, ErrDataNotPresent
 	}
 

--- a/pkg/virtualization/vmdk/streamoptimized.go
+++ b/pkg/virtualization/vmdk/streamoptimized.go
@@ -226,7 +226,7 @@ func (v *StreamOptimizedImage) read(grainOffset int64) ([]byte, error) {
 	}
 	defer zr.Close()
 
-	grainDataSize := v.Header.GrainSize * Sector
+	grainDataSize := int64(v.SparseExtentHeader.GrainSize) * Sector
 	decompressedData := make([]byte, grainDataSize)
 	n, err := io.ReadFull(zr, decompressedData)
 	if err != nil {
@@ -240,7 +240,7 @@ func (v *StreamOptimizedImage) read(grainOffset int64) ([]byte, error) {
 }
 
 func (v *StreamOptimizedImage) grainDataSize() int64 {
-	return v.Header.GrainSize * Sector
+	return int64(v.SparseExtentHeader.GrainSize) * Sector
 }
 
 func (v *StreamOptimizedImage) ReadAt(p []byte, off int64) (int, error) {
@@ -327,7 +327,7 @@ func (v *StreamOptimizedImage) TranslateOffset(off int64) (int64, int64, error) 
 	// grainSize: 128
 	// sector: 512
 	// grain: 64KB (decompressed deflate)
-	grain := v.Header.GrainSize * Sector
+	grain := int64(v.SparseExtentHeader.GrainSize) * Sector
 
 	// number GTEs per GT: 512
 	// gtSize: 32MB

--- a/pkg/virtualization/vmdk/streamoptimized.go
+++ b/pkg/virtualization/vmdk/streamoptimized.go
@@ -81,6 +81,16 @@ func parseSparseExtentHeader(rs io.ReadSeeker) (SparseExtentHeader, error) {
 		return SparseExtentHeader{}, xerrors.Errorf("invalid magick number: actual(0x%08x), expected(0x%08x)", h.MagicNumber, KDMV)
 	}
 
+	// Reject unknown incompatible flags
+	unknownIncompat := h.Flags & incompatFlagsMask & ^knownIncompatFlags
+	if unknownIncompat != 0 {
+		return SparseExtentHeader{}, xerrors.Errorf("unknown incompatible flags: 0x%08x", unknownIncompat)
+	}
+	// EMBEDDED_LBA requires COMPRESSED
+	if h.Flags&FlagEmbeddedLBA != 0 && h.Flags&FlagCompressed == 0 {
+		return SparseExtentHeader{}, xerrors.Errorf("EMBEDDED_LBA flag requires COMPRESSED flag")
+	}
+
 	return h, nil
 }
 

--- a/pkg/virtualization/vmdk/streamoptimized.go
+++ b/pkg/virtualization/vmdk/streamoptimized.go
@@ -358,6 +358,12 @@ func (v *StreamOptimizedImage) TranslateOffset(off int64) (int64, int64, error) 
 		v.GTCache[gtOffset] = gt
 	}
 
+	// logical grain data offset.
+	// offset: 32MB + 4KB
+	// gtSize: 32MB
+	// grain: 64KB
+	// entryIndex: 0
+	// grainOffset gt[entryOffset]
 	entryIndex := off % gtSize / grain
 	if entryIndex >= int64(len(gt.Entries)) {
 		return 0, 0, ErrDataNotPresent
@@ -371,6 +377,8 @@ func (v *StreamOptimizedImage) TranslateOffset(off int64) (int64, int64, error) 
 		return 0, 0, ErrDataNotPresent
 	}
 
+	// dataOffset: 4KB
+	// dataOffset less than grain(default: 64KB)
 	dataOffset := off % gtSize % grain
 
 	return int64(grainOffset), dataOffset, nil

--- a/pkg/virtualization/vmdk/streamoptimized.go
+++ b/pkg/virtualization/vmdk/streamoptimized.go
@@ -359,12 +359,13 @@ func (v *StreamOptimizedImage) TranslateOffset(off int64) (int64, int64, error) 
 		return 0, 0, ErrDataNotPresent
 	}
 	grainOffset := gt.Entries[entryIndex]
-	if grainOffset == 0 {
+	if grainOffset == GTEEmpty {
+		return 0, 0, ErrDataNotPresent
+	}
+	if grainOffset == GTEZeroed && v.SparseExtentHeader.Flags&uint32(FlagUseZeroedGrainTableEntry) != 0 {
 		return 0, 0, ErrDataNotPresent
 	}
 
-	// dataOffset: 4KB
-	// dataOffset less than grain(default: 64KB)
 	dataOffset := off % gtSize % grain
 
 	return int64(grainOffset), dataOffset, nil

--- a/pkg/virtualization/vmdk/streamoptimized.go
+++ b/pkg/virtualization/vmdk/streamoptimized.go
@@ -369,11 +369,7 @@ func (v *StreamOptimizedImage) TranslateOffset(off int64) (int64, int64, error) 
 		return 0, 0, ErrDataNotPresent
 	}
 	grainOffset := gt.Entries[entryIndex]
-	if grainOffset == GTEEmpty {
-		return 0, 0, ErrDataNotPresent
-	}
-	// Per VMDK spec, GTE=1 is a valid sector offset when FlagUseZeroedGrainTableEntry is not set
-	if grainOffset == GTEZeroed && v.SparseExtentHeader.Flags&FlagUseZeroedGrainTableEntry != 0 {
+	if isGTEAbsent(grainOffset, v.SparseExtentHeader.Flags) {
 		return 0, 0, ErrDataNotPresent
 	}
 

--- a/pkg/virtualization/vmdk/streamoptimized.go
+++ b/pkg/virtualization/vmdk/streamoptimized.go
@@ -337,6 +337,9 @@ func (v *StreamOptimizedImage) TranslateOffset(off int64) (int64, int64, error) 
 	// gtSize: 32MB
 	// gtIndex: 1
 	gtIndex := off / gtSize
+	if gtIndex >= int64(len(v.GD.Entries)) {
+		return 0, 0, ErrDataNotPresent
+	}
 	gtOffset := int64(v.GD.Entries[gtIndex])
 	if gtOffset == 0 {
 		return 0, 0, ErrDataNotPresent
@@ -351,13 +354,10 @@ func (v *StreamOptimizedImage) TranslateOffset(off int64) (int64, int64, error) 
 		v.GTCache[gtOffset] = gt
 	}
 
-	// logical grain data offset.
-	// offset: 32MB + 4KB
-	// gtSize: 32MB
-	// grain: 64KB
-	// entryIndex: 0
-	// grainOffset gt[entryOffset]
 	entryIndex := off % gtSize / grain
+	if entryIndex >= int64(len(gt.Entries)) {
+		return 0, 0, ErrDataNotPresent
+	}
 	grainOffset := gt.Entries[entryIndex]
 	if grainOffset == 0 {
 		return 0, 0, ErrDataNotPresent

--- a/pkg/virtualization/vmdk/streamoptimized.go
+++ b/pkg/virtualization/vmdk/streamoptimized.go
@@ -81,14 +81,8 @@ func parseSparseExtentHeader(rs io.ReadSeeker) (SparseExtentHeader, error) {
 		return SparseExtentHeader{}, xerrors.Errorf("invalid magick number: actual(0x%08x), expected(0x%08x)", h.MagicNumber, KDMV)
 	}
 
-	// Reject unknown incompatible flags
-	unknownIncompat := h.Flags & incompatFlagsMask & ^knownIncompatFlags
-	if unknownIncompat != 0 {
-		return SparseExtentHeader{}, xerrors.Errorf("unknown incompatible flags: 0x%08x", unknownIncompat)
-	}
-	// EMBEDDED_LBA requires COMPRESSED
-	if h.Flags&FlagEmbeddedLBA != 0 && h.Flags&FlagCompressed == 0 {
-		return SparseExtentHeader{}, xerrors.Errorf("EMBEDDED_LBA flag requires COMPRESSED flag")
+	if err := validateIncompatFlags(h.Flags); err != nil {
+		return SparseExtentHeader{}, err
 	}
 
 	return h, nil

--- a/pkg/virtualization/vmdk/streamoptimized.go
+++ b/pkg/virtualization/vmdk/streamoptimized.go
@@ -366,7 +366,8 @@ func (v *StreamOptimizedImage) TranslateOffset(off int64) (int64, int64, error) 
 	if grainOffset == GTEEmpty {
 		return 0, 0, ErrDataNotPresent
 	}
-	if grainOffset == GTEZeroed && v.SparseExtentHeader.Flags&uint32(FlagUseZeroedGrainTableEntry) != 0 {
+	// Per VMDK spec, GTE=1 is a valid sector offset when FlagUseZeroedGrainTableEntry is not set
+	if grainOffset == GTEZeroed && v.SparseExtentHeader.Flags&FlagUseZeroedGrainTableEntry != 0 {
 		return 0, 0, ErrDataNotPresent
 	}
 

--- a/pkg/virtualization/vmdk/vmdk.go
+++ b/pkg/virtualization/vmdk/vmdk.go
@@ -172,6 +172,13 @@ func ParseHeader(r io.Reader) (Header, error) {
 	return header, nil
 }
 
+// isGTEAbsent returns true if the grain table entry indicates no data.
+// Per VMDK spec, GTE=1 is a valid sector offset when FlagUseZeroedGrainTableEntry is not set.
+func isGTEAbsent(entry Entry, flags uint32) bool {
+	return entry == GTEEmpty ||
+		(entry == GTEZeroed && flags&FlagUseZeroedGrainTableEntry != 0)
+}
+
 // validateIncompatFlags rejects unknown incompatible flags and
 // validates flag combinations per the VMDK spec.
 func validateIncompatFlags(flags uint32) error {

--- a/pkg/virtualization/vmdk/vmdk.go
+++ b/pkg/virtualization/vmdk/vmdk.go
@@ -166,7 +166,23 @@ func ParseHeader(r io.Reader) (Header, error) {
 	if header.Signature != KDMV {
 		return Header{}, xerrors.Errorf("invalid signature: actual(0x%08x), expected(0x%08x)", header.Signature, KDMV)
 	}
+	if err := validateIncompatFlags(uint32(header.Flag)); err != nil {
+		return Header{}, err
+	}
 	return header, nil
+}
+
+// validateIncompatFlags rejects unknown incompatible flags and
+// validates flag combinations per the VMDK spec.
+func validateIncompatFlags(flags uint32) error {
+	unknownIncompat := flags & incompatFlagsMask & ^knownIncompatFlags
+	if unknownIncompat != 0 {
+		return xerrors.Errorf("unknown incompatible flags: 0x%08x", unknownIncompat)
+	}
+	if flags&FlagEmbeddedLBA != 0 && flags&FlagCompressed == 0 {
+		return xerrors.Errorf("EMBEDDED_LBA flag requires COMPRESSED flag")
+	}
+	return nil
 }
 
 func Open(rs io.ReadSeeker, cache Cache[string, []byte]) (*io.SectionReader, error) {

--- a/pkg/virtualization/vmdk/vmdk_test.go
+++ b/pkg/virtualization/vmdk/vmdk_test.go
@@ -1,9 +1,12 @@
 package vmdk_test
 
 import (
+	"bytes"
+	"encoding/binary"
 	"io"
 	"os"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/masahiro331/go-vmdk-parser/pkg/virtualization/vmdk"
@@ -264,6 +267,69 @@ func TestReadAll(t *testing.T) {
 			t.Errorf("ReadAll() byte[%d] = 0x%02x, want 0x00", i, b)
 			break
 		}
+	}
+}
+
+// makeHeader creates a binary-encoded VMDK header for testing.
+func makeHeader(h vmdk.Header) []byte {
+	var buf bytes.Buffer
+	binary.Write(&buf, binary.LittleEndian, h)
+	return buf.Bytes()
+}
+
+func TestParseHeaderIncompatFlags(t *testing.T) {
+	validHeader := vmdk.Header{
+		Signature: 0x564d444b, // KDMV
+		Version:   1,
+		GrainSize: 128,
+	}
+
+	tests := []struct {
+		name    string
+		flag    int32
+		wantErr string
+	}{
+		{
+			name: "no flags",
+			flag: 0,
+		},
+		{
+			name: "compressed flag only",
+			flag: int32(0x00010000),
+		},
+		{
+			name: "compressed and embedded_lba",
+			flag: int32(0x00010000 | 0x00020000),
+		},
+		{
+			name:    "unknown incompatible flag",
+			flag:    int32(0x00040000),
+			wantErr: "unknown incompatible flags",
+		},
+		{
+			name:    "embedded_lba without compressed",
+			flag:    int32(0x00020000),
+			wantErr: "EMBEDDED_LBA flag requires COMPRESSED flag",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := validHeader
+			h.Flag = tt.flag
+			_, err := vmdk.ParseHeader(bytes.NewReader(makeHeader(h)))
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("ParseHeader() unexpected error: %v", err)
+				}
+			} else {
+				if err == nil {
+					t.Fatal("ParseHeader() should return error")
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("error should contain %q, got: %v", tt.wantErr, err)
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

This PR improves the robustness of `StreamOptimizedImage` and `MonolithicSparseImage` by addressing several VMDK spec compliance issues that can cause panics or silent data corruption:

- **Bounds checks in `TranslateOffset`**: Prevent `panic: index out of range` when the image capacity is not a multiple of `NumberGTEsPerGT × GrainSize`, or when qemu-img produces GTE counts exceeding capacity
  - Spec: [libvmdk §5.5 Grain table](https://github.com/libyal/libvmdk/blob/main/documentation/VMWare%20Virtual%20Disk%20Format%20(VMDK).asciidoc#55-grain-table)
- **Zeroed-grain table entry (GTE=1) support**: Handle the `FlagUseZeroedGrainTableEntry` flag per the VMDK spec, preventing GTE=1 from being misinterpreted as a valid sector offset
  - Spec: [libvmdk §5.2 Flags](https://github.com/libyal/libvmdk/blob/main/documentation/VMWare%20Virtual%20Disk%20Format%20(VMDK).asciidoc#52-flags), [open-vmdk `vmware_vmdk.h` L59](https://github.com/vmware/open-vmdk/blob/master/vmdk/vmware_vmdk.h#L59)
- **Footer header reference unification**: Use `SparseExtentHeader` (footer) consistently in `StreamOptimizedImage` instead of the placeholder primary header
- **Incompatible flag validation**: Reject unknown incompatible flags and invalid flag combinations (e.g., `EMBEDDED_LBA` without `COMPRESSED`) at parse time in both `ParseHeader` and `parseSparseExtentHeader`
  - Spec: [open-vmdk `vmware_vmdk.h` L56-L62](https://github.com/vmware/open-vmdk/blob/master/vmdk/vmware_vmdk.h#L56-L62), [open-vmdk `sparse.c` L193-L230](https://github.com/vmware/open-vmdk/blob/master/vmdk/sparse.c#L193-L230)

## Note

This PR may conflict with #4 (`feat/thread_safe`) as both modify `streamoptimized.go`. The changes are complementary.

## Test plan

- [x] `TestParseHeaderIncompatFlags` — validates flag acceptance/rejection for 5 cases
- [x] Existing tests pass

---

## 概要

`StreamOptimizedImage` と `MonolithicSparseImage` の堅牢性を向上させ、パニックやサイレントなデータ破損を引き起こすVMDK仕様準拠の問題を修正します：

- **`TranslateOffset` の境界チェック**: イメージの capacity が `NumberGTEsPerGT × GrainSize` の倍数でない場合や、qemu-img 生成のVMDKで GTE 総数が capacity を超えるケースでの `panic: index out of range` を防止
  - 仕様: [libvmdk §5.5 Grain table](https://github.com/libyal/libvmdk/blob/main/documentation/VMWare%20Virtual%20Disk%20Format%20(VMDK).asciidoc#55-grain-table)
- **Zeroed-grain table entry (GTE=1) 対応**: VMDK仕様に従い `FlagUseZeroedGrainTableEntry` フラグを処理し、GTE=1 が有効なセクタオフセットとして誤解釈されるのを防止
  - 仕様: [libvmdk §5.2 Flags](https://github.com/libyal/libvmdk/blob/main/documentation/VMWare%20Virtual%20Disk%20Format%20(VMDK).asciidoc#52-flags), [open-vmdk `vmware_vmdk.h` L59](https://github.com/vmware/open-vmdk/blob/master/vmdk/vmware_vmdk.h#L59)
- **Footer ヘッダ参照の統一**: `StreamOptimizedImage` でプレースホルダの先頭ヘッダではなく `SparseExtentHeader`（footer）を一貫して使用
- **Incompatible フラグの検証**: `ParseHeader` と `parseSparseExtentHeader` の両方で、未知の incompatible フラグや無効なフラグの組み合わせ（`EMBEDDED_LBA` without `COMPRESSED`）をパース時に拒否
  - 仕様: [open-vmdk `vmware_vmdk.h` L56-L62](https://github.com/vmware/open-vmdk/blob/master/vmdk/vmware_vmdk.h#L56-L62), [open-vmdk `sparse.c` L193-L230](https://github.com/vmware/open-vmdk/blob/master/vmdk/sparse.c#L193-L230)

## 備考

#4 (`feat/thread_safe`) と `streamoptimized.go` でコンフリクトする可能性がありますが、変更内容は補完的です。

## テスト

- [x] `TestParseHeaderIncompatFlags` — 5ケースのフラグ受理/拒否を検証
- [x] 既存テスト通過